### PR TITLE
Remove 3.4.x dependencies and clean up buildpack.toml

### DIFF
--- a/buildpack.toml
+++ b/buildpack.toml
@@ -14,26 +14,6 @@ api = "0.2"
   [[metadata.dependencies]]
     id = "python"
     name = "Python"
-    sha256 = "cefa2b44d2b4ce351bc4e19769b17911cd5198729e58d48465790d677999cb21"
-    source = "https://www.python.org/ftp/python/3.4.9/Python-3.4.9.tgz"
-    source_sha256 = "e02e565372750a6678efe35ddecbe5ccd5330a8a2e8bbe38d3060713492e3dab"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/python/python-3.4.9-linux-x64-cflinuxfs3-cefa2b44.tgz"
-    version = "3.4.9"
-
-  [[metadata.dependencies]]
-    id = "python"
-    name = "Python"
-    sha256 = "1c06f7a78b3893a5d5c6fb97dfa2cab53c5ac6de6edbae9b7b376f24717ca970"
-    source = "https://www.python.org/ftp/python/3.4.10/Python-3.4.10.tgz"
-    source_sha256 = "217757699249ab432571b381386d441e12b433100ab5f908051fcb7cced2539d"
-    stacks = ["org.cloudfoundry.stacks.cflinuxfs3"]
-    uri = "https://buildpacks.cloudfoundry.org/dependencies/python/python-3.4.10-linux-x64-cflinuxfs3-1c06f7a7.tgz"
-    version = "3.4.10"
-
-  [[metadata.dependencies]]
-    id = "python"
-    name = "Python"
     sha256 = "a278e2f47f3c38a785647cc8924f67b2512a7a07b12861b6ad69497e71605782"
     source = "https://www.python.org/ftp/python/3.5.8/Python-3.5.8.tgz"
     source_sha256 = "18c88dfd260147bc7247e6356010e5d4916dfbfc480f6434917f88e61228177a"
@@ -113,12 +93,6 @@ api = "0.2"
     version = "3.8.2"
 
   [[metadata.dependency_deprecation_dates]]
-    date = 2019-03-16T00:00:00Z
-    link = "https://www.python.org/dev/peps/pep-0429/"
-    name = "Python"
-    version_line = "3.4.x"
-
-  [[metadata.dependency_deprecation_dates]]
     date = 2020-09-13T00:00:00Z
     link = "https://www.python.org/dev/peps/pep-0478/"
     name = "Python"
@@ -140,24 +114,6 @@ api = "0.2"
     date = 2023-06-27T00:00:00Z
     link = "https://www.python.org/dev/peps/pep-0537/"
     name = "Python"
-    version_line = "3.8.x"
-
-  [[metadata.dependency_deprecation_dates]]
-    date = 2021-12-23T00:00:00Z
-    link = "https://www.python.org/dev/peps/pep-0494/"
-    name = "python"
-    version_line = "3.6.x"
-
-  [[metadata.dependency_deprecation_dates]]
-    date = 2023-06-27T00:00:00Z
-    link = "https://www.python.org/dev/peps/pep-0537/"
-    name = "python"
-    version_line = "3.7.x"
-
-  [[metadata.dependency_deprecation_dates]]
-    date = 2023-06-27T00:00:00Z
-    link = "https://www.python.org/dev/peps/pep-0537/"
-    name = "python"
     version_line = "3.8.x"
 
 [[stacks]]


### PR DESCRIPTION
Removes the 3.4.x dependencies which are out of support the duplicated dependency deprecation sections